### PR TITLE
Fix Jest build error by configuring Babel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Babel
+        run: npm install --save-dev @babel/core @babel/preset-env
+
+      - name: Configure Jest to use Babel
+        run: echo '{ "presets": ["@babel/preset-env"] }' > babel.config.json
+
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "@vercel/ncc": "^0.36.1",
     "chai": "^5.0.0",
     "jest": "^29.7.0"
+  },
+  "jest": {
+    "transformIgnorePatterns": ["/node_modules/(?!chai)"]
   }
 }


### PR DESCRIPTION
Update Jest configuration to handle ECMAScript Modules and fix test errors.

* **package.json**
  - Add `"transformIgnorePatterns": ["/node_modules/(?!chai)"]` to Jest configuration.

* **.github/workflows/ci.yml**
  - Add a step to install Babel.
  - Add a step to configure Jest to use Babel for transformation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wzbmui/action-gh-blog-feed/pull/2?shareId=d1eabf30-95a1-40c8-880a-b228acbbed53).