### PR TITLE
Sort blog entries by date (descending)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GitHub Action that lists [GitHub Blog](https://github.blog/) entries that matc
 - `token` - A token with `repo` scope
 - `dry-run` - If `true`, the RSS feed will only be reported in the console log. If `false`, an issue will be created to list all RSS feed entries found.
 - `labels` - A multi-line list of labels to search for. E.g. including `actions` will trigger the following search; `https://github.blog/feed/?s=actions`
+- `days` - The number of days worth of posts to include in the list
 
 ## Outputs
 
@@ -41,14 +42,11 @@ jobs:
           labels: |
             'actions'
             'copilot'
+          days: 7
 ```
 
 ## ToDo
 
-- [ ] Sort blog entries by date (descending)
-- [ ] Include for each entry in list:
-  - Date of posting
-- [ ] Allow input parameter for how many days worth of posts should be included in list
 - [ ] Reformat / polish to include blog post date span in issue title 
 - [ ] Check and fix for vulnerable coding patterns
 - [ ] Use GITHUB_TOKEN for API authentication if possible

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   labels:
     description: Multi-line list of labels to filter on
     required: true
+  days:
+    description: Number of days worth of posts to include in the list
+    required: true
+    default: '7'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ async function run() {
     const token = core.getInput('token');
     const dryRun = core.getBooleanInput('dry-run');
     const labels = core.getMultilineInput('labels');
+    const days = core.getInput('days');
 
     const baseUrl = 'https://github.blog/feed/?s=';
     const octokit = github.getOctokit(token);
@@ -23,9 +24,15 @@ async function run() {
       await _formatAndPrintLogOutput(feed);
     }
 
+    // Filter feeds by date
+    const filteredFeeds = _filterFeedsByDate(allFeeds, days);
+
+    // Sort feeds by date in descending order
+    filteredFeeds.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+
     // TODO: Create an issue in the workflow repo listing all rss feed items with their hyperlink, publication date, and title. Label the issue as "news-update".
     if (!dryRun) {
-      const issueBody = allFeeds.map(item => `- [${item.title}](${item.link})`).join('\n');
+      const issueBody = filteredFeeds.map(item => `- [${item.title}](${item.link}) - ${item.pubDate}`).join('\n');
       const issue = await octokit.rest.issues.create({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -35,7 +42,7 @@ async function run() {
       });
     }
 
-    core.setOutput('feeds', JSON.stringify(allFeeds));
+    core.setOutput('feeds', JSON.stringify(filteredFeeds));
 
   } catch (error) {
     core.setFailed(error.message);
@@ -65,9 +72,26 @@ async function _formatAndPrintLogOutput(feed) {
   });
 }
 
+/**
+ * Filters the feeds by the given number of days.
+ * @param {Array} feeds - The array of feed items.
+ * @param {number} days - The number of days to filter by.
+ * @returns {Array} - The filtered array of feed items.
+ */
+function _filterFeedsByDate(feeds, days) {
+  const now = new Date();
+  return feeds.filter(item => {
+    const pubDate = new Date(item.pubDate);
+    const diffTime = Math.abs(now - pubDate);
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays <= days;
+  });
+}
+
 module.exports = {
   _getRssFeed,
-  _formatAndPrintLogOutput
+  _formatAndPrintLogOutput,
+  _filterFeedsByDate
 };
 
 run();


### PR DESCRIPTION
Add sorting of blog entries by date in descending order and include the date of posting for each entry.

* **index.js**
  - Add input parameter for the number of days worth of posts to include in the list.
  - Filter feeds by date based on the input parameter.
  - Sort feeds by date in descending order.
  - Include the publication date for each entry in the issue body.
  - Update the output to include the filtered feeds.

* **README.md**
  - Update usage example to include the new input parameter for days.
  - Remove to-do items related to sorting and including the date of posting.

* **action.yml**
  - Add new input parameter for days.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wzbmui/action-gh-blog-feed/pull/3?shareId=39017395-c391-48a9-b53e-e362f82fd749).