### PR TITLE
Sort blog entries by date (descending)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   labels:
     description: Multi-line list of labels to filter on
     required: true
+  days:
+    description: Number of days worth of posts to include
+    required: false
+    default: 7
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ async function run() {
     const token = core.getInput('token');
     const dryRun = core.getBooleanInput('dry-run');
     const labels = core.getMultilineInput('labels');
+    const days = core.getInput('days');
 
     const baseUrl = 'https://github.blog/feed/?s=';
     const octokit = github.getOctokit(token);
@@ -23,19 +24,22 @@ async function run() {
       await _formatAndPrintLogOutput(feed);
     }
 
-    // TODO: Create an issue in the workflow repo listing all rss feed items with their hyperlink, publication date, and title. Label the issue as "news-update".
+    const filteredFeeds = _filterFeedsByDate(allFeeds, days);
+    const sortedFeeds = _sortFeedsByDate(filteredFeeds);
+
     if (!dryRun) {
-      const issueBody = allFeeds.map(item => `- [${item.title}](${item.link})`).join('\n');
+      const issueBody = sortedFeeds.map(item => `- [${item.title}](${item.link}) - ${item.pubDate}`).join('\n');
+      const issueTitle = _getIssueTitle(sortedFeeds);
       const issue = await octokit.rest.issues.create({
-      owner: github.context.repo.owner,
-      repo: github.context.repo.repo,
-      title: 'News Update',
-      body: issueBody,
-      labels: ['news-update']
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        title: issueTitle,
+        body: issueBody,
+        labels: ['news-update']
       });
     }
 
-    core.setOutput('feeds', JSON.stringify(allFeeds));
+    core.setOutput('feeds', JSON.stringify(sortedFeeds));
 
   } catch (error) {
     core.setFailed(error.message);
@@ -49,6 +53,28 @@ async function _getRssFeed(url, label) {
   const feed = await parser.parseURL(rssFeedUrl);
 
   return feed;
+}
+
+function _filterFeedsByDate(feeds, days) {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+
+  return feeds.filter(feed => new Date(feed.pubDate) >= cutoffDate);
+}
+
+function _sortFeedsByDate(feeds) {
+  return feeds.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+}
+
+function _getIssueTitle(feeds) {
+  if (feeds.length === 0) {
+    return 'News Update';
+  }
+
+  const firstDate = new Date(feeds[0].pubDate);
+  const lastDate = new Date(feeds[feeds.length - 1].pubDate);
+
+  return `News Update (${firstDate.toDateString()} - ${lastDate.toDateString()})`;
 }
 
 /**


### PR DESCRIPTION
Add sorting and filtering of blog entries by date, and include date of posting in issue body.

* **index.js**
  - Add input parameter for the number of days worth of posts to include.
  - Filter blog entries based on the number of days worth of posts to include.
  - Sort blog entries by date in descending order.
  - Include the date of posting for each entry in the issue body.
  - Update the issue title to include the blog post date span.

* **action.yml**
  - Add input parameter for the number of days worth of posts to include.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wzbmui/action-gh-blog-feed/pull/4?shareId=e1546c80-2754-4221-9401-d8c734e3b22f).